### PR TITLE
post_publish hook for Ruby 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ export BBB_GID="$(cat /etc/passwd | grep bigbluebutton | cut -d: -f4)"
 envsubst < ./snippets/post_publish_bbb_video_download.rb.template > /usr/local/bigbluebutton/core/scripts/post_publish/a0_post_publish_bbb_video_download.rb
 ## bbb v2.3:
 envsubst < ./snippets/bbb23_post_publish_bbb_video_download.rb.template > /usr/local/bigbluebutton/core/scripts/post_publish/a0_post_publish_bbb_video_download.rb
+## bbb v2.3 with Ruby 2.7
+envsubst < ./snippets/bbb23_ruby27_post_publish_bbb_video_download.rb.template > /usr/local/bigbluebutton/core/scripts/post_publish/a0_post_publish_bbb_video_download.rb
 ```
 
 ## Update

--- a/snippets/bbb23_ruby27_post_publish_bbb_video_download.rb.template
+++ b/snippets/bbb23_ruby27_post_publish_bbb_video_download.rb.template
@@ -1,0 +1,59 @@
+#!/usr/bin/ruby
+# encoding: UTF-8
+
+#
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+#
+# Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3.0 of the License, or (at your option)
+# any later version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+#
+
+require "optparse"
+require File.expand_path('../../../lib/recordandplayback', __FILE__)
+
+meeting_id = nil
+OptionParser.new do |opts|
+  opts.on('-m', '--meeting-id MEETING_ID', 'Internal Meeting ID') do |v|
+    meeting_id = v
+  end
+  opts.on('-f', '--format FORMAT', 'Recording Format') do |v|
+  end
+end.parse!
+
+logger = Logger.new("/var/log/bigbluebutton/post_publish.log", 'weekly' )
+logger.level = Logger::INFO
+BigBlueButton.logger = logger
+
+published_files = "/var/bigbluebutton/published/presentation/#{meeting_id}"
+meeting_metadata = BigBlueButton::Events.get_meeting_metadata("/var/bigbluebutton/recording/raw/#{meeting_id}/events.xml")
+
+#
+### Main Code
+#
+
+require 'shellwords'
+input_dir = Shellwords.escape(published_files)
+output_file = Shellwords.escape("#{published_files}/video.mp4")
+base_dir = '${BBB_VIDEO_DOWNLOAD_DIR}'
+
+BigBlueButton.logger.info("Create downloadable video for [#{meeting_id}] start")
+
+rs = "cd #{base_dir} && docker-compose run --rm --user ${BBB_UID}:${BBB_GID} app node index.js -i #{input_dir} -o #{output_file}"
+system(rs) # run shell script in Ruby 2.7
+
+BigBlueButton.logger.info(rs)
+BigBlueButton.logger.info("Create downloadable video for [#{meeting_id}] end")
+
+exit 0


### PR DESCRIPTION
Based on the issue #84, the post_publish hook cannot run in Ruby 2.7.
I found the `system()` function is worked for me.
So I create `snippets/bbb23_ruby27_post_publish_bbb_video_download.rb.template` and give a feedback for you.

Thanks for your project. It helps me a lot.