### PR TITLE
Add 777 permissions to /tmp

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:12-alpine
+RUN chmod 777 -R /tmp
 RUN apk add --no-cache chromium ffmpeg
 RUN adduser -D bigbluebutton bigbluebutton
 USER bigbluebutton


### PR DESCRIPTION
In my own instalation of bbb-video-download I had the following problem: 

```javascript
[Error] Failed rendering downloable video for BBB presentation  {
  args: Namespace(input='/var/bigbluebutton/published/presentation/8f3e67448ad0224c5022b14d1ad12eb2eb0c58ac-1689589539497', output='/var/bigbluebutton/download/8f3e67448ad0224c5022b14d1ad12eb2eb0c58ac-1689589539497.mp4'),
  format: 'mp4',
  docker: true,
  workdir: './tmp/datalNIaHA'
} [Error: EACCES: permission denied, mkdtemp '/tmp/puppeteer_dev_chrome_profile-XXXXXX'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdtemp',
  path: '/tmp/puppeteer_dev_chrome_profile-XXXXXX'
}
``` 
I was able to solve it by adding 777 permissions to `/tmp` directory